### PR TITLE
Allow for optional file ending specification (i.e. to open a scratchpad with markdown syntax)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ return {
       end,
       desc = "Toggle Scratchpad",
     },
+    { -- optional custom filetype
+      "<leader>sm",
+      function()
+        vim.cmd("silent! ChknToggle md")
+      end,
+      desc = "Toggle Markdown Scratchpad",
+    },
   },
 }
 ```

--- a/lua/chkn/init.lua
+++ b/lua/chkn/init.lua
@@ -5,8 +5,8 @@ function M.setup(user_config)
 end
 
 -- Register the ChknToggle command globally
-vim.api.nvim_create_user_command("ChknToggle", function()
-	require("chkn.scratchpad").open()
-end, { desc = "Toggle Chkn" })
+vim.api.nvim_create_user_command("ChknToggle", function(args)
+	require("chkn.scratchpad").open(args.args)
+end, { nargs = "?", desc = "Toggle Chkn" })
 
 return M

--- a/lua/chkn/scratchpad.lua
+++ b/lua/chkn/scratchpad.lua
@@ -58,6 +58,8 @@ function M.open(file_ending)
 			vim.api.nvim_buf_set_lines(M._state.buf, 0, -1, false, vim.fn.readfile(M._config.path .. file_ending))
 		end
 
+    vim.cmd("do BufReadPost")
+
 		-- Set autocommands for persistence
 		if M._config.persistent then
 			vim.api.nvim_create_autocmd("BufWriteCmd", {

--- a/lua/chkn/scratchpad.lua
+++ b/lua/chkn/scratchpad.lua
@@ -51,14 +51,16 @@ function M.open(file_ending)
     if not ft then
       ft = "text"
     end
-		vim.api.nvim_buf_set_option(M._state.buf, "ft", ft)
 
 		-- Load persistent content if enabled
 		if M._config.persistent and vim.fn.filereadable(M._config.path .. file_ending) == 1 then
 			vim.api.nvim_buf_set_lines(M._state.buf, 0, -1, false, vim.fn.readfile(M._config.path .. file_ending))
 		end
 
-    vim.cmd("do BufReadPost")
+    vim.defer_fn(function()
+      vim.cmd("do BufNewFile")
+      vim.api.nvim_buf_set_option(M._state.buf, "ft", ft)
+    end, 10)
 
 		-- Set autocommands for persistence
 		if M._config.persistent then

--- a/lua/chkn/scratchpad.lua
+++ b/lua/chkn/scratchpad.lua
@@ -115,7 +115,11 @@ end
 function M.save(buf, file_ending)
 	if M._config.persistent then
 		local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-		vim.fn.writefile(lines, M._config.path .. file_ending)
+    if #lines == 1 and lines[1] == "" then
+      os.remove(M._config.path .. file_ending)
+    else
+      vim.fn.writefile(lines, M._config.path .. file_ending)
+    end
 	end
 end
 


### PR DESCRIPTION
# Description

Added an optional argument to `ChknToggle` to allow for an arbitrary file ending to be attached.
This enables opening of scratchpads that have syntax highlighting, snippets, completions, etc for an arbitrary language of the user's choice.

## Checklist

- [x] Code compiles and passes tests.
- [ ] Tests have been added for new functionality.
- [x] Documentation has been updated where necessary.
